### PR TITLE
Use REST API instead of XmlHttpRequest

### DIFF
--- a/Announce.php
+++ b/Announce.php
@@ -12,7 +12,7 @@ class AnnouncePlugin extends MantisPlugin {
 
 		$this->version = "2.2.0-dev";
 		$this->requires		= array(
-			"MantisCore" => "2.0.0",
+			"MantisCore" => "2.3.0",
 		);
 
 		$this->author		= "John Reese";
@@ -33,6 +33,8 @@ class AnnouncePlugin extends MantisPlugin {
 			"EVENT_MENU_MANAGE" => "menu_manage",
 
 			"EVENT_LAYOUT_BODY_BEGIN" => "body_begin",
+
+			'EVENT_REST_API_ROUTES' => 'routes',
 		);
 	}
 
@@ -104,5 +106,83 @@ class AnnouncePlugin extends MantisPlugin {
 			# 2017-10-26 - v2.2.0
 			array( 'UpdateFunction', 'delete_orphans_dismissals' ),
 		);
+	}
+
+	/**
+	 * Add the RESTful routes handled by this plugin.
+	 *
+	 * @param string $p_event_name The event name
+	 * @param array  $p_event_args The event arguments
+	 * @return void
+	 */
+	public function routes( $p_event_name, $p_event_args ) {
+		$t_app = $p_event_args['app'];
+		$t_plugin = $this;
+		$t_app->group(
+			plugin_route_group(),
+			function() use ( $t_app, $t_plugin ) {
+				$t_app->get( '/dismiss/{context_id}', [$t_plugin, 'route_dismiss'] );
+			}
+		);
+	}
+
+	/**
+	 * RESTful route for Announcement dismissal.
+	 *
+	 * Returned JSON structure
+	 *   - {string} title
+	 *   - {string} text
+	 *
+	 * @param Psr\Http\Message\ServerRequestInterface $request
+	 * @param Psr\Http\Message\ResponseInterface $response
+	 * @param array $args
+	 * @return Psr\Http\Message\ResponseInterface
+	 */
+	public function route_dismiss( $request, $response, $args) {
+		$t_timestamp = time();
+		$t_user_id = auth_get_current_user_id();
+
+		# Set the reference Context Id for dismissal
+		$t_context_id = (int)$args['context_id'];
+
+		# Make sure the message context actually exists
+		$t_context = AnnounceContext::load_by_id( $t_context_id );
+		if( !$t_context ) {
+			return $response->withStatus( HTTP_STATUS_BAD_REQUEST );
+		}
+
+		plugin_push_current( $this->basename );
+
+		# Dismiss announcement if dismissable or a time-to-live has been set
+		if( $t_context->dismissable || $t_context->ttl > 0 ) {
+			$t_dismissed_table = plugin_table( 'dismissed' );
+
+			# check for existing dismissal
+			$t_query = "SELECT * FROM {$t_dismissed_table} 
+				WHERE context_id=" . db_param() . " 
+				AND user_id=".db_param();
+			$t_result = db_query( $t_query, array( $t_context_id, $t_user_id ) );
+
+			if( db_num_rows( $t_result ) < 1 ) {
+				$t_query = "INSERT INTO {$t_dismissed_table} 
+					(context_id, user_id, timestamp) 
+					VALUES 
+					(" . db_param( ) . ", " . db_param() . ", " . db_param() . ")";
+				$t_param = array( $t_context_id, $t_user_id, $t_timestamp );
+			} else  {
+				$t_query = "UPDATE {$t_dismissed_table} 
+					SET timestamp = " . db_param() . " 
+					WHERE context_id=" . db_param() . " 
+					AND user_id=" . db_param();
+				$t_param = array( $t_timestamp, $t_context_id, $t_user_id );
+			}
+			db_query( $t_query, $t_param );
+
+			$response = $response->withJson( $t_context_id );
+		}
+
+		plugin_pop_current();
+
+		return $response->withStatus( HTTP_STATUS_SUCCESS );
 	}
 }

--- a/Announce.php
+++ b/Announce.php
@@ -148,10 +148,18 @@ class AnnouncePlugin extends MantisPlugin {
 
 		# Make sure the message context actually exists
 		# and that it can actually be dismissed (i.e. marked as dismissable,
-		# or  a time-to-live has been set).
+		# or a time-to-live has been set).
 		$t_context = AnnounceContext::load_by_id( $t_context_id );
-		if( !$t_context || !$t_context->dismissable && $t_context->ttl == 0 ) {
-			return $response->withStatus( HTTP_STATUS_BAD_REQUEST );
+		if( !$t_context ) {
+			return $response->withStatus(
+				HTTP_STATUS_BAD_REQUEST,
+				'Invalid Context Id'
+			);
+		} elseif( !$t_context->dismissable && $t_context->ttl == 0 ) {
+			return $response->withStatus(
+				HTTP_STATUS_BAD_REQUEST,
+				'Non-dismissible announcement'
+			);
 		}
 
 		plugin_push_current( $this->basename );
@@ -182,12 +190,14 @@ class AnnouncePlugin extends MantisPlugin {
 		}
 		if( db_query( $t_query, $t_param ) ) {
 			$t_status = HTTP_STATUS_SUCCESS;
+			$t_msg = '';
 		} else {
 			$t_status = HTTP_STATUS_INTERNAL_SERVER_ERROR;
+			$t_msg = 'Announcement dismissal failed';
 		}
 
 		plugin_pop_current();
 
-		return $response->withStatus( $t_status );
+		return $response->withStatus( $t_status, $t_msg );
 	}
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ specification.
 
 ### Changed
 
+- Minimum requirement: MantisBT 2.0.0 → 2.3.0  
+- Use REST API instead of XmlHttpRequest
+  ([#21](https://github.com/mantisbt-plugins/snippets/issues/21))
 - Improve error handling of announcements dismissals
 - Code cleanup
 
@@ -32,7 +35,7 @@ specification.
   ([#18](https://github.com/mantisbt-plugins/Announce/issues/18),
   [#19](https://github.com/mantisbt-plugins/Announce/issues/19))
 - Cascade delete Dismissals when removing a Context or Message
-  [#17](https://github.com/mantisbt-plugins/Announce/issues/17))
+  ([#17](https://github.com/mantisbt-plugins/Announce/issues/17))
 - Time-to-live for non-dismissable announcements
   ([#16](https://github.com/mantisbt-plugins/Announce/issues/16))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ specification.
 ### Changed
 
 - Improve error handling of announcements dismissals
+- Code cleanup
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ messages.
 
 ## Requirements
 
-- MantisBT 2.0.0 or above
+- MantisBT 2.3.0 or above
 
 If you need compatibility with older releases of MantisBT, please use legacy
 versions of the plugin, as per table below:

--- a/api/context.php
+++ b/api/context.php
@@ -4,30 +4,6 @@
 # Copyright (c) 2017 Damien Regad
 # Licensed under the MIT license
 
-/**
- * Generate HTML row to be inserted while editing an announcement.
- */
-function xmlhttprequest_plugin_announce_add_context() {
-	plugin_push_current("Announce");
-
-	$row = gpc_get_int("row");
-	$message_id = gpc_get_int("message_id");
-?>
-<tr class="row-<?php echo $row ?>">
-<td class="center">
-<a class="announce_delete_context_new" href="#" data-message-id="<?php echo $message_id ?>"><img src="<?php echo plugin_file("delete.png") ?>" alt="-" border="0"/></a>
-<input type="hidden" name="context_new[]" value="<?php echo $message_id ?>"/></td>
-<td class="center"><select name="location_new[]"><?php Announce::print_location_option_list() ?></select></td>
-<td class="center"><select name="project_new[]"><?php print_project_option_list() ?></select></td>
-<td class="center"><select name="access_new[]"><?php print_enum_string_option_list("access_levels", VIEWER) ?></select></td>
-<td class="center"><input name="ttl_new[]" value="0" size="8"/></td>
-<td class="center"><input type="checkbox" name="dismissable_new[]" checked="checked"/></td>
-</tr>
-<?php
-
-	plugin_pop_current();
-}
-
 class AnnounceContext {
 	public $id;
 	public $message_id;

--- a/api/context.php
+++ b/api/context.php
@@ -15,7 +15,7 @@ function xmlhttprequest_plugin_announce_add_context() {
 ?>
 <tr class="row-<?php echo $row ?>">
 <td class="center">
-<a class="announce_delete_context_new" href="#"><img src="<?php echo plugin_file("delete.png") ?>" alt="-" border="0"/></a>
+<a class="announce_delete_context_new" href="#" data-message-id="<?php echo $message_id ?>"><img src="<?php echo plugin_file("delete.png") ?>" alt="-" border="0"/></a>
 <input type="hidden" name="context_new[]" value="<?php echo $message_id ?>"/></td>
 <td class="center"><select name="location_new[]"><?php Announce::print_location_option_list() ?></select></td>
 <td class="center"><select name="project_new[]"><?php print_project_option_list() ?></select></td>

--- a/api/dismiss.php
+++ b/api/dismiss.php
@@ -4,42 +4,6 @@
 # Copyright (c) 2017 Damien Regad
 # Licensed under the MIT license
 
-/**
- * Generate HTML row to be inserted while editing an announcement.
- */
-function xmlhttprequest_plugin_announce_dismiss() {
-	plugin_push_current("Announce");
-	$timestamp = time();
-
-	$context_id = gpc_get_int("context_id");
-	$user_id = auth_get_current_user_id();
-
-	# make sure the message context actually exists
-	$context = AnnounceContext::load_by_id($context_id);
-
-	# Dismiss announcement if dismissable or a time-to-live has been set
-	if ($context && ( $context->dismissable || $context->ttl > 0 ) ) {
-		$dismissed_table = plugin_table("dismissed");
-
-		# check for existing dismissal
-		$query = "SELECT * FROM {$dismissed_table} WHERE context_id=".db_param()." AND user_id=".db_param();
-		$result = db_query($query, array($context_id, $user_id));
-
-		if (db_num_rows($result) < 1) {
-			$query = "INSERT INTO {$dismissed_table} (context_id, user_id, timestamp) VALUES (".db_param().", ".db_param().", ".db_param().")";
-			db_query($query, array($context_id, $user_id, $timestamp));
-		} else  {
-			$query = "UPDATE {$dismissed_table} SET timestamp = ".db_param()." WHERE context_id=".db_param()." AND user_id=".db_param();
-			db_query($query, array($timestamp, $context_id, $user_id, ));
-		}
-
-		# echoing the context ID as "success"
-		echo json_encode($context_id);
-	}
-
-	plugin_pop_current();
-}
-
 class AnnounceDismissed {
 	/**
 	 * Delete dismissals for the given Context ID.

--- a/files/announce.js
+++ b/files/announce.js
@@ -45,7 +45,9 @@ jQuery(document).ready(function($) {
 
 		$.ajax({
 			type: 'POST',
-			url: 'api/rest/plugins/Announce/dismiss/' + context_id,
+			// Using the full URL (through index.php) to avoid issues on sites
+			// where URL rewriting is not working (#31)
+			url: 'api/rest/index.php/plugins/Announce/dismiss/' + context_id,
 			success: function() {
 				$(announcement).fadeOut();
 			},

--- a/files/announce.js
+++ b/files/announce.js
@@ -44,17 +44,10 @@ jQuery(document).ready(function($) {
 		}
 
 		$.ajax({
-			dataType: 'json',
+			type: 'POST',
 			url: 'api/rest/plugins/Announce/dismiss/' + context_id,
-			success: function(data) {
-				if (data === context_id) {
-					$(announcement).fadeOut();
-				} else {
-					console.error(
-						'Unexpected output received from announcement dismissal',
-						{ output: data, request: this.url }
-					)
-				}
+			success: function() {
+				$(announcement).fadeOut();
 			},
 			error: function(xhr, textStatus, errorThrown) {
 				console.error(

--- a/files/announce.js
+++ b/files/announce.js
@@ -2,6 +2,22 @@
 // Copyright (c) 2017 Damien Regad
 // Licensed under the MIT license
 
+/**
+ * Namespace for global function used in list_action.js
+ */
+var Announce = Announce || {};
+
+/**
+ * Return MantisBT REST API URL for given endpoint
+ * @param {string} endpoint
+ * @returns {string} REST API URL
+ */
+Announce.rest_api = function(endpoint) {
+	// Using the full URL (through index.php) to avoid issues on sites
+	// where URL rewriting is not working (#31)
+	return "api/rest/index.php/plugins/Announce/" + endpoint;
+};
+
 jQuery(document).ready(function($) {
 	var announcement = $('div.announcement');
 
@@ -45,9 +61,7 @@ jQuery(document).ready(function($) {
 
 		$.ajax({
 			type: 'POST',
-			// Using the full URL (through index.php) to avoid issues on sites
-			// where URL rewriting is not working (#31)
-			url: 'api/rest/index.php/plugins/Announce/dismiss/' + context_id,
+			url: Announce.rest_api('dismiss/') + context_id,
 			success: function() {
 				$(announcement).fadeOut();
 			},

--- a/files/announce.js
+++ b/files/announce.js
@@ -45,7 +45,7 @@ jQuery(document).ready(function($) {
 
 		$.ajax({
 			dataType: 'json',
-			url: 'xmlhttprequest.php?entrypoint=plugin_announce_dismiss&context_id=' + context_id,
+			url: 'api/rest/plugins/Announce/dismiss/' + context_id,
 			success: function(data) {
 				if (data === context_id) {
 					$(announcement).fadeOut();

--- a/files/list_action.js
+++ b/files/list_action.js
@@ -10,13 +10,13 @@ jQuery(document).ready(function($) {
 
 	function delete_action (event){
 		if ($(this).hasClass("announce_delete_context_added")) {
-			var row = $("td.announce_list_"+$(this).attr("value"));
+			var row = $("td.announce_list_" + $(this).data('message-id'));
 			row.prop("rowspan", row.prop("rowspan")-1);
 			$(this).parents("tr").remove();
 			return;
 		}
 
-		var context_id = $(this).attr("value");
+		var context_id = $(this).data("context-id");
 
 		var input_deleted = "input[name='context_delete_"+context_id+"']";
 		var input_location = "select[name='location_"+context_id+"']";
@@ -49,7 +49,7 @@ jQuery(document).ready(function($) {
 
 	// "adding" a new context from edit list
 	$("a.announce_add_context").click(function(event){
-		var message_id = $(this).attr("value");
+		var message_id = $(this).data('message-id');
 		var categoryrow = $(this).parents("tr");
 
 		$.ajax({

--- a/files/list_action.js
+++ b/files/list_action.js
@@ -53,7 +53,6 @@ jQuery(document).ready(function($) {
 		var categoryrow = $(this).parents("tr");
 
 		$.ajax({
-			async: false,
 			dataType: "html",
 			url: Announce.rest_api('context/') + message_id,
 			success: function(data) {

--- a/files/list_action.js
+++ b/files/list_action.js
@@ -55,7 +55,7 @@ jQuery(document).ready(function($) {
 		$.ajax({
 			async: false,
 			dataType: "html",
-			url: "xmlhttprequest.php?entrypoint=plugin_announce_add_context&row=1&message_id="+message_id,
+			url: Announce.rest_api('context/') + message_id,
 			success: function(data) {
 				var row = $("td.announce_list_"+message_id);
 				row.prop("rowspan", row.prop("rowspan")+1);

--- a/pages/list_action.php
+++ b/pages/list_action.php
@@ -113,7 +113,7 @@ if ($action == "delete") {
 
 							<tr class="row-category">
 								<td class="category">
-									<a class="announce_add_context" href="#">
+									<a class="announce_add_context" href="#" data-message-id="<?php echo $message_id ?>">
 										<img src="<?php echo plugin_file("add.png") ?>" alt="+" border="0"/>
 									</a>
 								</td>
@@ -129,7 +129,7 @@ if ($action == "delete") {
 ?>
 							<tr>
 								<td class="center">
-									<a class="announce_delete_context" href="#">
+									<a class="announce_delete_context" href="#" data-context-id="<?php echo $context_id ?>">
 										<img src="<?php echo plugin_file("delete.png") ?>"
 											 alt="-" border="0"/>
 									</a>


### PR DESCRIPTION
XHR was deprecated in Mantis 2.3.0.

Publish REST API endpoints to replace the corresponding XHR functions:

- xmlhttprequest_plugin_announce_dismiss
  => ./plugins/Announce/dismiss/{context_id}
- xmlhttprequest_plugin_announce_add_context
  => ./plugins/Announce/context/{message_id}

Fixes #21