### PR TITLE
Add footer display, display all announcements and dismissable option configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .idea/
 *.kdev4
 nbproject/
+.vscode/

--- a/Announce.php
+++ b/Announce.php
@@ -32,6 +32,8 @@ class AnnouncePlugin extends MantisPlugin {
 	function config() {
 		return array(
 			"manage_threshold" => MANAGER,
+			"display_all" => NO,
+			"default_dismissable" => YES,
 		);
 	}
 
@@ -40,8 +42,9 @@ class AnnouncePlugin extends MantisPlugin {
 			"EVENT_CORE_READY" => "api",
 			"EVENT_LAYOUT_RESOURCES" => "resources",
 			"EVENT_MENU_MANAGE" => "menu_manage",
-
+			
 			"EVENT_LAYOUT_BODY_BEGIN" => "body_begin",
+			"EVENT_LAYOUT_BODY_END" => "body_end",
 
 			'EVENT_REST_API_ROUTES' => 'routes',
 		);
@@ -79,8 +82,21 @@ class AnnouncePlugin extends MantisPlugin {
 	}
 
 	function body_begin() {
-		Announce::display("header", null, "announcement-header");
+		if (plugin_config_get( "display_all" )) {
+			Announce::display_all("header", null, "announcement-header");
+		} else {
+			Announce::display("header", null, "announcement-header");
+		}
 	}
+
+	function body_end() {
+		if (plugin_config_get( "display_all" )) {
+			Announce::display_all("footer", null, "announcement-footer");
+		} else {
+			Announce::display("footer", null, "announcement-footer");
+		}
+	}
+
 
 	function schema() {
 		require_once("api/install.php");

--- a/files/announce.css
+++ b/files/announce.css
@@ -26,6 +26,11 @@
 	display: none;
 }
 
+/* Mobile-first: Ensures text wraps normally on small screens for better readability. */
+.category .small.wrap {
+	white-space: normal;
+}
+
 input.ttl {
 	width: 5em;
 }

--- a/files/announce.js
+++ b/files/announce.js
@@ -29,14 +29,18 @@ jQuery(document).ready(function($) {
 			$('#threshold_warning').hide();
 		}
 	});
-
-	// Move announcement to the page's top, between navbar and breadcrumbs
+	
 	var main_div = $('div.main-content');
 	if (!main_div.length) {
 		// Admin pages don't have a main-content div
 		main_div = $('div.main-container');
 	}
-	main_div.prepend($(announcement));
+	// Move header announcement to the page's top, between navbar and breadcrumbs
+	var announcement_header = announcement.filter('.announcement-header');
+	main_div.prepend($(announcement_header));
+	// Move footer announcement to the page's bottom, between page content and footer
+	var announcement_footer = announcement.filter('.announcement-footer');
+	main_div.append($(announcement_footer));
 
 	// Manual dismissal of announcement (user click)
 	$('img.announcement-dismiss').click(dismiss);

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -32,14 +32,17 @@ $s_plugin_Announce_config = 'Configuration';
 $s_plugin_Announce_config_title = 'Announcement Configuration';
 $s_plugin_Announce_config_manage_threshold = 'Manage Announcements';
 $s_plugin_Announce_threshold_warning = 'WARNING: access level is lower than <em>$g_manage_site_threshold</em> ; users may not be able to access the management pages.';
+$s_plugin_Announce_config_display_all = 'Display all announcements';
+$s_plugin_Announce_config_default_dismissable = 'Dismissable is enabled by default';
 
 $s_plugin_Announce_action_create = 'Create';
 $s_plugin_Announce_action_edit = 'Edit';
 $s_plugin_Announce_action_delete = 'Delete';
-$s_plugin_Announce_action_delete_confirm = 'Do you really want to delete the following announcements?';
+$s_plugin_Announce_action_delete_confirm = 'Do you really want to delete the following announcement?';
 $s_plugin_Announce_action_update = 'Update';
 
 $s_plugin_Announce_location_header = 'Page Header';
+$s_plugin_Announce_location_footer = 'Page Footer';
 
 $s_plugin_Announce_error_duplicate_context = 'A "%1$s" context is already defined for project "%2$s".';
 $s_plugin_Announce_error_unknown_location = 'Unknown context location "%1$s".';

--- a/lang/strings_hungarian.txt
+++ b/lang/strings_hungarian.txt
@@ -33,11 +33,13 @@ $s_plugin_Announce_config = 'Beállítások';
 $s_plugin_Announce_config_title = 'Közlemény konfiguráció';
 $s_plugin_Announce_config_manage_threshold = 'Közlemények kezelése';
 $s_plugin_Announce_threshold_warning = 'FIGYELEM: a hozzáférési szint alacsonyabb, mint az <em>$g_manage_site_threshold</em>; a felhasználók nem biztos, hogy hozzáférnek a kezelőfelületekhez.';
+$s_plugin_Announce_config_display_all = 'Összes közlemény megjelenítése';
+$s_plugin_Announce_config_default_dismissable = 'Elvethető alapértelmezésként';
 
 $s_plugin_Announce_action_create = 'Létrehozás';
 $s_plugin_Announce_action_edit = 'Szerkesztés';
 $s_plugin_Announce_action_delete = 'Törlés';
-$s_plugin_Announce_action_delete_confirm = 'Valóban törölni szeretné a következő közleményeket?';
+$s_plugin_Announce_action_delete_confirm = 'Valóban törölni szeretné a következő közleményt?';
 $s_plugin_Announce_action_update = 'Frissítés';
 
 $s_plugin_Announce_location_header = 'Oldal fejléc';

--- a/pages/config.php
+++ b/pages/config.php
@@ -15,6 +15,10 @@ function maybe_set_option( $name, $value ) {
 
 maybe_set_option("manage_threshold", gpc_get_int("manage_threshold"));
 
+maybe_set_option("display_all", gpc_get_bool("display_all"));
+
+maybe_set_option("default_dismissable", gpc_get_bool("default_dismissable"));
+
 form_security_purge("plugin_Announce_config");
 print_header_redirect(plugin_page("config_page", true));
 

--- a/pages/config_page.php
+++ b/pages/config_page.php
@@ -49,6 +49,26 @@ print_manage_menu();
 					</select>
 				</td>
 			</tr>
+
+			<tr>
+				<td class="category">
+					<?php echo plugin_lang_get( 'config_display_all' ) ?>
+				</td>
+				<td>
+					<input type="checkbox" name="display_all"
+						<?php check_checked( (bool)plugin_config_get( "display_all" ) ) ?>/>				
+				</td>
+			</tr>
+
+			<tr>
+				<td class="category">
+					<?php echo plugin_lang_get( 'config_default_dismissable' ) ?>
+				</td>
+				<td>
+					<input type="checkbox" name="default_dismissable"
+						<?php check_checked( (bool)plugin_config_get( "default_dismissable" ) ) ?>/>				
+				</td>
+			</tr>
 		</table>
 
 		</div>

--- a/pages/list.php
+++ b/pages/list.php
@@ -196,7 +196,7 @@ print_manage_menu( plugin_page( 'list' ) );
 								<td class="category">
 									<?php echo plugin_lang_get("access") ?>
 									<br>
-									<span class="small"><?php echo plugin_lang_get("access_help") ?></span>
+									<span class="small wrap"><?php echo plugin_lang_get("access_help") ?></span>
 								</td>
 								<td>
 									<select name="access">
@@ -209,16 +209,16 @@ print_manage_menu( plugin_page( 'list' ) );
 								<td class="category">
 									<?php echo plugin_lang_get("ttl") ?>
 									<br>
-									<span class="small"><?php echo plugin_lang_get("ttl_help") ?></span>
+									<span class="small wrap"><?php echo plugin_lang_get("ttl_help") ?></span>
 								</td>
 								<td>
 									<input name="ttl" class="ttl" type="number" value="0" min="0"/>
 								</td>
 							</tr>
 
-							<tr>
+							<tr>							
 								<td class="category"><?php echo plugin_lang_get("dismissable") ?></td>
-								<td><input type="checkbox" name="dismissable" checked="checked"/></td>
+								<td><input type="checkbox" name="dismissable" <?php check_checked( (bool)plugin_config_get( "default_dismissable" ) ) ?>/></td>
 							</tr>
 						</tbody>
 

--- a/pages/list_action_update.php
+++ b/pages/list_action_update.php
@@ -46,12 +46,10 @@ if( count( $t_message_list ) > 0 ) {
 			}
 		}
 
-		if( !is_blank( $t_new_title ) ) {
-			$t_message->title = $t_new_title;
-		}
-		if( !is_blank( $t_new_message ) ) {
-			$t_message->message = $t_new_message;
-		}
+		// Allow saving empty values for title and message to support scenarios where 
+		// clearing these fields is intentional (e.g., resetting or removing content).
+		$t_message->title = $t_new_title;
+		$t_message->message = $t_new_message;
 
 		$t_message->save();
 	}


### PR DESCRIPTION
Added configuration option to display announcements in the page footer.
Introduced a new config setting to display all announcements instead of one random announcement.
Introduced a new config setting to enable/disable dismissable announcements by default.